### PR TITLE
Update SpawnMenu.lua

### DIFF
--- a/Client/SpawnMenu.lua
+++ b/Client/SpawnMenu.lua
@@ -179,7 +179,7 @@ MainHUD:Subscribe("SpawnItem", function(category, asset_id)
 	local end_location = viewport_3D.Position + viewport_3D.Direction * trace_max_distance
 
 	-- Traces for world things
-    local trace_result = Trace.LineSingle(start_location, end_location, CollisionChannel.WorldStatic | CollisionChannel.WorldDynamic | CollisionChannel.Water)
+        local trace_result = Trace.LineSingle(start_location, end_location, CollisionType.Normal)
 
 	local spawn_location = end_location
 


### PR DESCRIPTION
Trace Collision type against most object so you can spawn props inside of big spawned rooms/buildings etc, without props spawning outside through walls