### PR TITLE
perf (`ToolGun`): reduce useless network usage

### DIFF
--- a/Server/Tools/BaseToolGun.lua
+++ b/Server/Tools/BaseToolGun.lua
@@ -19,7 +19,6 @@ function ToolGun:Constructor(location, rotation, color)
 	self:SetCrosshairMaterial("nanos-world::MI_Crosshair_Dot")
 	self:SetUsageSettings(false, false)
 
-	self:SetValue("Color", color, true)
 	self:SetMaterialColorParameter("Emissive", color * 100)
 end
 


### PR DESCRIPTION
A "Color" value was set on `ToolGun` instances and broadcasted to everyone while it wasn't used anywhere