### PR TITLE
Add `sv_allowcslua` convar: allow players to run Lua with `lua` command

### DIFF
--- a/Client/Index.lua
+++ b/Client/Index.lua
@@ -13,7 +13,6 @@ Input.Register("ContextMenu", "C", "Toggles the Context Menu")
 Input.Register("Undo", "X", "Destroy last spawned Item")
 
 -- Loads Package Files
-Package.Require("Config.lua")
 Package.Require("Notifications.lua")
 Package.Require("ContextMenu.lua")
 Package.Require("SpawnMenu.lua")

--- a/Package.toml
+++ b/Package.toml
@@ -36,6 +36,7 @@
 # and can be accessed through Server.GetCustomSettings() method from any package
 [custom_settings]
     enable_auto_weather = { label = "auto change weather", type = "boolean", description = "enable weather to change automatically", default = true }
+    enable_cslua = { label = "client-side lua", type = "boolean", description = "enable players to run Lua on client-side", default = false }
     enable_default_sky = { label = "spawn default sun & sky", type = "boolean", description = "enable overriding map lights with Ultra Dynamic Sky", default = true }
     enable_noclip = { label = "noclip", type = "boolean", description = "enable players to noclip", default = true }
     enable_pvp = { label = "pvp", type = "boolean", description = "enable players to shoot themselves", default = true }

--- a/Server/Index.lua
+++ b/Server/Index.lua
@@ -1,5 +1,3 @@
-Package.Require("Config.lua")
-
 -- List of Spawn Locations
 SPAWN_POINTS = Server.GetMapSpawnPoints()
 

--- a/Shared/BroadcastLua.lua
+++ b/Shared/BroadcastLua.lua
@@ -1,0 +1,23 @@
+local BROADCASTLUA = "BroadcastLua"
+
+-- Server-side
+if Server then
+  function BroadcastLua(code)
+    return Events.BroadcastRemote(BROADCASTLUA, code)
+  end
+
+  function Player.SendLua(player, code)
+    return Events.CallRemote(BROADCASTLUA, player, code)
+  end
+
+  Package.Export(BROADCASTLUA, BroadcastLua)
+  return
+end
+
+-- Client-side
+Events.SubscribeRemote(BROADCASTLUA, function(code)
+  local fn = load(code, BROADCASTLUA, "t")
+  if type(fn) == "function" then
+    pcall(fn)
+  end
+end)

--- a/Shared/BroadcastLua.lua
+++ b/Shared/BroadcastLua.lua
@@ -1,19 +1,20 @@
-local BROADCASTLUA = "BroadcastLua"
+local ID = "BroadcastLua"
 
 if Server then
 	function BroadcastLua(code)
-		return Events.BroadcastRemote(BROADCASTLUA, code)
+		return Events.BroadcastRemote(ID, code)
 	end
 
-	function Player.SendLua(player, code)
-		return Events.CallRemote(BROADCASTLUA, player, code)
+	function SendLua(player, code)
+		return Events.CallRemote(ID, player, code)
 	end
 
-	Package.Export(BROADCASTLUA, BroadcastLua)
+	Package.Export(ID, BroadcastLua)
+	Package.Export("SendLua", SendLua)
 else
 	-- Client-side
-	Events.SubscribeRemote(BROADCASTLUA, function(code)
-		local fn = load(code, BROADCASTLUA, "t")
+	Events.SubscribeRemote(ID, function(code)
+		local fn = load(code, ID, "t")
 		if type(fn) == "function" then
 			pcall(fn)
 		end

--- a/Shared/BroadcastLua.lua
+++ b/Shared/BroadcastLua.lua
@@ -1,23 +1,21 @@
 local BROADCASTLUA = "BroadcastLua"
 
--- Server-side
 if Server then
-  function BroadcastLua(code)
-    return Events.BroadcastRemote(BROADCASTLUA, code)
-  end
+	function BroadcastLua(code)
+		return Events.BroadcastRemote(BROADCASTLUA, code)
+	end
 
-  function Player.SendLua(player, code)
-    return Events.CallRemote(BROADCASTLUA, player, code)
-  end
+	function Player.SendLua(player, code)
+		return Events.CallRemote(BROADCASTLUA, player, code)
+	end
 
-  Package.Export(BROADCASTLUA, BroadcastLua)
-  return
+	Package.Export(BROADCASTLUA, BroadcastLua)
+else
+	-- Client-side
+	Events.SubscribeRemote(BROADCASTLUA, function(code)
+		local fn = load(code, BROADCASTLUA, "t")
+		if type(fn) == "function" then
+			pcall(fn)
+		end
+	end)
 end
-
--- Client-side
-Events.SubscribeRemote(BROADCASTLUA, function(code)
-  local fn = load(code, BROADCASTLUA, "t")
-  if type(fn) == "function" then
-    pcall(fn)
-  end
-end)

--- a/Shared/ClientsideLua.lua
+++ b/Shared/ClientsideLua.lua
@@ -1,6 +1,20 @@
 local ID = "sv_allowcslua"
 local Enabled = false -- disabled by default
 
+local function RunLua(...)
+	if select("#", ...) == 0 then return end
+	local code = table.concat({ ... }, " ")
+	local fn, err = load(code, nil, "t")
+	if type(fn) == "function" then
+		local ok, res = pcall(fn)
+		if res ~= nil then
+			Console.Log("[lua] %s", res)
+		end
+	else
+		Console.Log("[lua] %s", err)
+	end
+end
+
 if Server then
 	Enabled = Server.GetCustomSettings().enable_cslua or Enabled
 
@@ -37,6 +51,8 @@ if Server then
 			Chat.BroadcastMessage("Client-side Lua has been " .. (Enabled and "<green>enabled</>" or "<red>disabled</>"))
 		end
 	end, "enable players to run Lua on client-side", { "0/1" })
+
+	Console.RegisterCommand("lua", RunLua, "run Lua", { "code" })
 else
 	Enabled = Client.GetValue(ID, Enabled)
 
@@ -54,16 +70,8 @@ else
 
 	Console.RegisterCommand("lua", function(...)
 		--Enabled = Client.GetValue(ID, false) -- new approach
-		if not Enabled or select("#", ...) == 0 then return end
-		local code = table.concat({ ... }, " ")
-		local fn, err = load(code, nil, "t")
-		if type(fn) == "function" then
-			local ok, res = pcall(fn)
-			if res ~= nil then
-				Console.Log("[lua] %s", res)
-			end
-		else
-			Console.Log("[lua] %s", err)
+		if Enabled then
+			RunLua(...)
 		end
 	end, "run Lua (" .. ID .. " must be enabled on server-side)", { "code" })
 end

--- a/Shared/ClientsideLua.lua
+++ b/Shared/ClientsideLua.lua
@@ -1,0 +1,69 @@
+local ID = "sv_allowcslua"
+local Enabled = false -- disabled by default
+
+if Server then
+	Enabled = Server.GetCustomSettings().enable_cslua or Enabled
+
+	-- Broadcast the convar's value initially
+	Server.SetValue(ID, Enabled, true)
+	--Events.BroadcastRemote(ID, Enabled)
+
+	-- C2S: Query the convar's value; old approach
+	--Events.SubscribeRemote(ID, function(player)
+	--	Events.CallRemote(ID, player, Enabled)
+	--end)
+
+	Console.RegisterCommand(ID, function(enable)
+		local changed
+		if enable then
+			if enable == "1" then
+				changed = not Enabled
+				if changed then
+					Enabled = true
+					Server.SetValue(ID, Enabled, true)
+					Events.BroadcastRemote(ID, Enabled)
+				end
+			elseif enable == "0" then
+				changed = Enabled
+				if changed then
+					Enabled = false
+					Server.SetValue(ID, Enabled, true)
+					Events.BroadcastRemote(ID, Enabled)
+				end
+			end
+		end
+		if changed then -- only broadcast a message if the state has changed
+			Console.Log("Client-side Lua has been %s", Enabled and "enabled" or "disabled")
+			Chat.BroadcastMessage("Client-side Lua has been " .. (Enabled and "<green>enabled</>" or "<red>disabled</>"))
+		end
+	end, "enable players to run Lua on client-side", { "0/1" })
+else
+	Enabled = Client.GetValue(ID, Enabled)
+
+	-- S2C: synchronise convar state
+	Events.SubscribeRemote(ID, function(enable)
+		Enabled = not (not enable) -- old approach; make sure we have a boolean
+		--Enabled = Client.GetValue(ID, false) -- new approach
+		if Enabled then
+			Client.SetDebugEnabled(true)
+		end
+	end)
+
+	-- Query the convar's value initially
+	--Events.CallRemote(ID)
+
+	Console.RegisterCommand("lua", function(...)
+		--Enabled = Client.GetValue(ID, false) -- new approach
+		if not Enabled or select("#", ...) == 0 then return end
+		local code = table.concat({ ... }, " ")
+		local fn, err = load(code, nil, "t")
+		if type(fn) == "function" then
+			local ok, res = pcall(fn)
+			if res ~= nil then
+				Console.Log("[lua] %s", res)
+			end
+		else
+			Console.Log("[lua] %s", err)
+		end
+	end, "run Lua (" .. ID .. " must be enabled on server-side)", { "code" })
+end

--- a/Shared/Index.lua
+++ b/Shared/Index.lua
@@ -1,2 +1,3 @@
 Package.Require("Config.lua")
+Package.Require("BroadcastLua.lua")
 Package.Require("ClientsideLua.lua")

--- a/Shared/Index.lua
+++ b/Shared/Index.lua
@@ -1,0 +1,2 @@
+Package.Require("Config.lua")
+Package.Require("ClientsideLua.lua")


### PR DESCRIPTION
Inspired by GMod.

This PR adds a `enable_cslua` setting + server-side `sv_allowcslua` console command; if set to 1, it allows players to use `lua` console command to run Lua code, by default cslua is disabled.
It also adds `lua` console command on server-side, as well as new Lua functions for executing Lua code on all players (`BroadcastLua`), or only on the specific player (`SendLua`).

I have tested this on local server, and it works as expected.

Side quest: It would be a good idea to create a convar system/library around such ["custom settings"](https://github.com/nanos-world/nanos-world-sandbox/blob/43ffe257b4ce4ae0bb04e8c675d283b24a6cb987/Package.toml#L38-L54), so they could be changed using server console and also provide on-change callback (for when a value is changed).